### PR TITLE
Add cups plug to enable printing when installed via snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prospect-mail",
   "productName": "Prospect Mail",
-  "version": "0.5.0-beta",
+  "version": "0.5.1-beta",
   "main": "src/main.js",
   "description": "Unofficial desktop client for Microsoft Outlook",
   "homepage": "https://github.com/julian-alarcon/prospect-mail",
@@ -96,7 +96,8 @@
         "wayland",
         "upower-observe",
         "removable-media",
-        "mount-observe"
+        "mount-observe",
+        "cups"
       ],
       "publish": [
         "github",


### PR DESCRIPTION
With this change, the following commands are still required to
enable printing:

sudo snap install --edge cups
snap connect prospect-mail:cups cups:cups

It looks like the second command will not be required when
running a version of snapd with the following change:

https://github.com/snapcore/snapd/pull/10427